### PR TITLE
[game] Store config in user config directory

### DIFF
--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -86,24 +86,12 @@ macro_rules! block_on {
 
 pub type RuscMixer = Arc<DynamicMixerController<f32>>;
 
-//TODO: Move to platform files
-#[cfg(target_os = "windows")]
 pub fn default_game_dir() -> PathBuf {
-    let mut game_dir = directories::UserDirs::new()
+    let mut game_dir = directories::BaseDirs::new()
         .expect("Failed to get directories")
-        .document_dir()
-        .expect("Failed to get documents directory")
+        .config_dir()
         .to_path_buf();
-    game_dir.push("USC");
-    game_dir
-}
-#[cfg(not(target_os = "windows"))]
-pub fn default_game_dir() -> PathBuf {
-    let mut game_dir = directories::UserDirs::new()
-        .expect("Failed to get directories")
-        .home_dir()
-        .to_path_buf();
-    game_dir.push(".usc");
+    game_dir.push("usc");
     game_dir
 }
 


### PR DESCRIPTION
As per the documentation, this would store the `usc` folder with the config data in one of the following:

|Platform | Value                                 | Example                                  |
| ------- | ------------------------------------- | ---------------------------------------- |
| Linux   | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config                      |
| macOS   | `$HOME`/Library/Application Support   | /Users/Alice/Library/Application Support |
| Windows | `{FOLDERID_RoamingAppData}`           | C:\Users\Alice\AppData\Roaming           |

This won't copy any data, so you'll have to move the folder to the new expected location (unless it successfully generates a blank folder for you, which it doesn't for me), and also delete `maps.db`.