### PR TITLE
Misc code cleanups 1/?: missing_const_for_fn, suboptimal_flops

### DIFF
--- a/editor/src/action_stack.rs
+++ b/editor/src/action_stack.rs
@@ -19,7 +19,7 @@ impl<T> ActionStack<T>
 where
     T: Clone,
 {
-    pub fn new(original: T) -> Self {
+    pub const fn new(original: T) -> Self {
         ActionStack {
             original,
             undo_stack: Vec::new(),

--- a/editor/src/camera_widget.rs
+++ b/editor/src/camera_widget.rs
@@ -115,7 +115,9 @@ impl CameraView {
                     if n.l == 0 {
                         let (x, y) = screen.tick_to_pos(n.y);
 
-                        let x = x + i as f32 * lane_width + lane_width + screen.track_width / 2.0;
+                        let x = (i as f32).mul_add(lane_width, x)
+                            + lane_width
+                            + screen.track_width / 2.0;
                         let w = screen.track_width / 6.0;
                         let h = Self::TRACK_LENGH / 100.0;
 
@@ -126,8 +128,9 @@ impl CameraView {
                         );
                     } else {
                         for (x, y, h, _) in screen.interval_to_ranges(n) {
-                            let x =
-                                x + i as f32 * lane_width + lane_width + screen.track_width / 2.0;
+                            let x = (i as f32).mul_add(lane_width, x)
+                                + lane_width
+                                + screen.track_width / 2.0;
                             let w = screen.track_width / 6.0;
 
                             bt_hold_mesh.add_rect_with_uv(
@@ -155,8 +158,7 @@ impl CameraView {
                     if n.l == 0 {
                         let (x, y) = screen.tick_to_pos(n.y);
 
-                        let x = x
-                            + (i as f32 * lane_width * 2.0)
+                        let x = (i as f32 * lane_width).mul_add(2.0, x)
                             + screen.track_width / 2.0
                             + lane_width;
                         let w = lane_width * 2.0;
@@ -169,8 +171,7 @@ impl CameraView {
                         );
                     } else {
                         for (x, y, h, _) in screen.interval_to_ranges(n) {
-                            let x = x
-                                + (i as f32 * lane_width * 2.0)
+                            let x = (i as f32 * lane_width).mul_add(2.0, x)
                                 + screen.track_width / 2.0
                                 + lane_width;
                             let w = lane_width * 2.0;

--- a/editor/src/chart_editor.rs
+++ b/editor/src/chart_editor.rs
@@ -367,7 +367,7 @@ impl ScreenState {
         self.track_width / 6.0
     }
 
-    pub fn ticks_per_col(&self) -> u32 {
+    pub const fn ticks_per_col(&self) -> u32 {
         self.beats_per_col.saturating_mul(self.beat_res)
     }
 

--- a/editor/src/lib.rs
+++ b/editor/src/lib.rs
@@ -247,7 +247,7 @@ impl From<egui::Modifiers> for Modifiers {
 }
 
 impl KeyCombo {
-    fn new(key: egui::Key, modifiers: Modifiers) -> Self {
+    const fn new(key: egui::Key, modifiers: Modifiers) -> Self {
         Self { key, modifiers }
     }
 }
@@ -300,7 +300,7 @@ impl std::fmt::Display for KeyCombo {
 
 #[allow(unused)]
 impl Modifiers {
-    fn new() -> Self {
+    const fn new() -> Self {
         Self {
             alt: false,
             command: false,
@@ -310,11 +310,11 @@ impl Modifiers {
         }
     }
 
-    fn alt(mut self) -> Self {
+    const fn alt(mut self) -> Self {
         self.alt = true;
         self
     }
-    fn command(mut self) -> Self {
+    const fn command(mut self) -> Self {
         self.command = true;
         self
     }
@@ -324,21 +324,21 @@ impl Modifiers {
         self
     }
     #[cfg(not(target_os = "macos"))]
-    fn ctrl(mut self) -> Self {
+    const fn ctrl(mut self) -> Self {
         self.ctrl = true;
         self.command = true;
         self
     }
-    fn mac_cmd(mut self) -> Self {
+    const fn mac_cmd(mut self) -> Self {
         self.mac_cmd = true;
         self
     }
-    fn shift(mut self) -> Self {
+    const fn shift(mut self) -> Self {
         self.shift = true;
         self
     }
 
-    fn any(self) -> bool {
+    const fn any(self) -> bool {
         self.alt || self.command || self.ctrl || self.mac_cmd || self.shift
     }
 }

--- a/editor/src/param_input.rs
+++ b/editor/src/param_input.rs
@@ -24,7 +24,7 @@ impl<'a, T: Clone> ParamEditor<'a, T> {
 }
 
 #[allow(unused)]
-fn is_filename<T>(v: &EffectParameter<T>) -> bool {
+const fn is_filename<T>(v: &EffectParameter<T>) -> bool {
     matches!(
         (&v.off, &v.on),
         (kson::parameter::EffectParameterValue::Filename(_), _)

--- a/editor/src/tools/bpm_ts.rs
+++ b/editor/src/tools/bpm_ts.rs
@@ -20,7 +20,7 @@ pub struct BpmTool {
 }
 
 impl BpmTool {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         BpmTool {
             bpm: 120.0,
             state: CursorToolStates::None,
@@ -151,7 +151,7 @@ pub struct TimeSigTool {
 }
 
 impl TimeSigTool {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         TimeSigTool {
             ts: kson::TimeSignature(4, 4),
             state: CursorToolStates::None,

--- a/editor/src/tools/buttons.rs
+++ b/editor/src/tools/buttons.rs
@@ -20,7 +20,7 @@ pub struct ButtonInterval {
 }
 
 impl ButtonInterval {
-    pub fn new(fx: bool) -> Self {
+    pub const fn new(fx: bool) -> Self {
         ButtonInterval {
             pressed: false,
             fx,

--- a/editor/src/tools/buttons.rs
+++ b/editor/src/tools/buttons.rs
@@ -191,14 +191,16 @@ impl CursorObject for ButtonInterval {
             let (x, y) = state.screen.tick_to_pos(self.interval.y);
 
             let x = if self.fx {
-                x + self.lane as f32 * state.screen.lane_width() * 2.0
-                    + 2.0 * self.lane as f32
-                    + state.screen.lane_width()
+                2.0f32.mul_add(
+                    self.lane as f32,
+                    (self.lane as f32 * state.screen.lane_width()).mul_add(2.0, x),
+                ) + state.screen.lane_width()
                     + state.screen.track_width / 2.0
             } else {
-                x + self.lane as f32 * state.screen.lane_width()
-                    + 1.0 * self.lane as f32
-                    + state.screen.lane_width()
+                1.0f32.mul_add(
+                    self.lane as f32,
+                    (self.lane as f32).mul_add(state.screen.lane_width(), x),
+                ) + state.screen.lane_width()
                     + state.screen.track_width / 2.0
             };
 
@@ -215,14 +217,16 @@ impl CursorObject for ButtonInterval {
             let mut long_bt_builder = Vec::<Shape>::new();
             for (x, y, h, _) in state.screen.interval_to_ranges(&self.interval) {
                 let x = if self.fx {
-                    x + self.lane as f32 * state.screen.lane_width() * 2.0
-                        + 2.0 * self.lane as f32
-                        + state.screen.lane_width()
+                    2.0f32.mul_add(
+                        self.lane as f32,
+                        (self.lane as f32 * state.screen.lane_width()).mul_add(2.0, x),
+                    ) + state.screen.lane_width()
                         + state.screen.track_width / 2.0
                 } else {
-                    x + self.lane as f32 * state.screen.lane_width()
-                        + 1.0 * self.lane as f32
-                        + state.screen.lane_width()
+                    1.0f32.mul_add(
+                        self.lane as f32,
+                        (self.lane as f32).mul_add(state.screen.lane_width(), x),
+                    ) + state.screen.lane_width()
                         + state.screen.track_width / 2.0
                 };
 

--- a/editor/src/tools/camera.rs
+++ b/editor/src/tools/camera.rs
@@ -233,7 +233,7 @@ impl CursorObject for CameraTool {
 
         let camera = ChartCamera {
             center: vec3(0.0, 0.0, 0.0),
-            angle: -45.0 - 14.0 * self.angle,
+            angle: 14.0f32.mul_add(-self.angle, -45.0),
             fov: 70.0,
             radius: (-self.radius + 3.1) / 2.0,
             tilt: 0.0,

--- a/editor/src/tools/laser.rs
+++ b/editor/src/tools/laser.rs
@@ -29,7 +29,7 @@ enum LaserEditMode {
 }
 
 impl LaserTool {
-    pub fn new(right: bool) -> Self {
+    pub const fn new(right: bool) -> Self {
         LaserTool {
             right,
             mode: LaserEditMode::None,
@@ -37,7 +37,7 @@ impl LaserTool {
         }
     }
 
-    fn gsp(ry: u32, v: f64) -> GraphSectionPoint {
+    const fn gsp(ry: u32, v: f64) -> GraphSectionPoint {
         GraphSectionPoint {
             ry,
             v,

--- a/game/src/animation.rs
+++ b/game/src/animation.rs
@@ -202,7 +202,7 @@ impl VgAnimation {
         }
     }
 
-    fn next_image(&self) -> usize {
+    const fn next_image(&self) -> usize {
         (self.current_image + 1) % self.image_count
     }
 }

--- a/game/src/button_codes.rs
+++ b/game/src/button_codes.rs
@@ -177,7 +177,7 @@ pub enum UscButton {
 }
 
 impl UscButton {
-    pub fn to_gilrs_code_u32(self) -> u32 {
+    pub const fn to_gilrs_code_u32(self) -> u32 {
         match self {
             UscButton::BT(bt) => match bt {
                 BtLane::A => 1,
@@ -197,7 +197,7 @@ impl UscButton {
         }
     }
 
-    pub fn as_str(&self) -> &str {
+    pub const fn as_str(&self) -> &str {
         match self {
             UscButton::BT(bt) => match bt {
                 BtLane::A => "BT A",
@@ -330,14 +330,14 @@ impl From<LaserSideAxis> for LaserAxis {
 pub struct LaserState(LaserAxis, LaserAxis);
 
 impl LaserState {
-    pub fn get(&self, side: Side) -> LaserSideAxis {
+    pub const fn get(&self, side: Side) -> LaserSideAxis {
         match side {
             Side::Left => LaserSideAxis::Left(self.0),
             Side::Right => LaserSideAxis::Right(self.1),
         }
     }
 
-    pub fn get_axis(&self, side: Side) -> LaserAxis {
+    pub const fn get_axis(&self, side: Side) -> LaserAxis {
         match side {
             Side::Left => self.0,
             Side::Right => self.1,

--- a/game/src/game.rs
+++ b/game/src/game.rs
@@ -165,15 +165,15 @@ pub struct HitSummary {
 }
 
 impl HitSummary {
-    pub fn new(crit: u32, good: u32, miss: u32) -> Self {
+    pub const fn new(crit: u32, good: u32, miss: u32) -> Self {
         Self { crit, good, miss }
     }
 
-    pub fn perfect(&self) -> bool {
+    pub const fn perfect(&self) -> bool {
         self.good == 0 && self.miss == 0
     }
 
-    pub fn full_combo(&self) -> bool {
+    pub const fn full_combo(&self) -> bool {
         self.miss == 0
     }
 }
@@ -204,7 +204,7 @@ impl From<&[HitRating]> for HitSummary {
 }
 
 impl HitRating {
-    pub fn delta(self) -> f64 {
+    pub const fn delta(self) -> f64 {
         match self {
             HitRating::None => f64::NAN,
             HitRating::Crit { delta, .. }
@@ -213,7 +213,7 @@ impl HitRating {
         }
     }
 
-    pub fn time(self) -> f64 {
+    pub const fn time(self) -> f64 {
         match self {
             HitRating::None => f64::NAN,
             HitRating::Crit { time, .. }
@@ -234,7 +234,7 @@ impl HitRating {
         }
     }
 
-    pub fn crit(self) -> bool {
+    pub const fn crit(self) -> bool {
         match self {
             HitRating::None => true,
             HitRating::Crit { .. } => true,
@@ -242,7 +242,7 @@ impl HitRating {
         }
     }
 
-    pub fn hit(self) -> bool {
+    pub const fn hit(self) -> bool {
         !matches!(self, HitRating::Miss { .. })
     }
 }
@@ -1012,7 +1012,7 @@ impl Game {
     }
 
     pub const MAX_SCORE: u64 = 10_000_000_u64;
-    fn actual_display_score(&self) -> u64 {
+    const fn actual_display_score(&self) -> u64 {
         let max = self.score_summary.total as u64 * 2;
         Self::MAX_SCORE * self.real_score / max
     }
@@ -1182,11 +1182,11 @@ impl Game {
         Ok(())
     }
 
-    fn auto_buttons(&self) -> bool {
+    const fn auto_buttons(&self) -> bool {
         matches!(self.autoplay, AutoPlay::All | AutoPlay::Buttons)
     }
 
-    fn auto_lasers(&self) -> bool {
+    const fn auto_lasers(&self) -> bool {
         matches!(self.autoplay, AutoPlay::All | AutoPlay::Lasers)
     }
 

--- a/game/src/game/camera.rs
+++ b/game/src/game/camera.rs
@@ -23,7 +23,7 @@ pub enum CameraSpin {
 }
 
 impl CameraSpin {
-    pub fn active_at(&self, tick: u32) -> bool {
+    pub const fn active_at(&self, tick: u32) -> bool {
         match self {
             CameraSpin::Half(s) => s.0 <= tick && s.0 + s.2 >= tick,
             CameraSpin::Full(s) => s.0 <= tick && s.0 + s.2 >= tick,
@@ -71,7 +71,7 @@ pub struct CameraShake {
 }
 
 impl CameraShake {
-    pub fn new(amplitude: f32, direction: f32, frequency: f32, duration: f32) -> Self {
+    pub const fn new(amplitude: f32, direction: f32, frequency: f32, duration: f32) -> Self {
         Self {
             amplitude,
             direction,
@@ -128,7 +128,7 @@ impl Default for ChartCamera {
 }
 
 impl ChartCamera {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         ChartCamera {
             kson_angle: 0.0,
             kson_radius: 0.0,

--- a/game/src/game/chart_view.rs
+++ b/game/src/game/chart_view.rs
@@ -246,7 +246,7 @@ impl ChartView {
                         continue;
                     }
                     let w = 1.0 / 3.0;
-                    let x = 1.0 / 3.0 + (1.0 / 3.0) * i as f32;
+                    let x = (1.0f32 / 3.0f32).mul_add(i as f32, 1.0 / 3.0);
                     let h = if n.l == 0 {
                         chip_h
                     } else {

--- a/game/src/game/gauge.rs
+++ b/game/src/game/gauge.rs
@@ -139,7 +139,7 @@ const fn tick_is_short(score_tick: PlacedScoreTick) -> bool {
 }
 
 fn hard_drain_multiplier(value: f32) -> f32 {
-    f32::clamp(1.0 - ((0.3 - value) * 2.0), 0.5, 1.0)
+    f32::clamp((0.3 - value).mul_add(-2.0, 1.0), 0.5, 1.0)
 }
 
 impl Gauge {

--- a/game/src/game/gauge.rs
+++ b/game/src/game/gauge.rs
@@ -28,7 +28,7 @@ impl TryFrom<Gauge> for GaugeType {
 }
 
 impl GaugeType {
-    pub fn fallback_supported(self) -> bool {
+    pub const fn fallback_supported(self) -> bool {
         match self {
             GaugeType::Normal => false,
             GaugeType::Hard => true,
@@ -88,7 +88,7 @@ pub struct Gauges {
 }
 
 impl Gauges {
-    pub fn new(active: Gauge, fallback: VecDeque<Gauge>) -> Self {
+    pub const fn new(active: Gauge, fallback: VecDeque<Gauge>) -> Self {
         Self {
             active,
             fallback,
@@ -125,7 +125,7 @@ impl Gauges {
     }
 }
 
-fn tick_is_short(score_tick: PlacedScoreTick) -> bool {
+const fn tick_is_short(score_tick: PlacedScoreTick) -> bool {
     match score_tick.tick {
         ScoreTick::Laser { lane: _, pos: _ } => false,
         ScoreTick::Slam {
@@ -151,7 +151,7 @@ impl Gauge {
         }
     }
 
-    pub fn miss_drain_percent(&self) -> f32 {
+    pub const fn miss_drain_percent(&self) -> f32 {
         match self {
             Gauge::None => 0.02,
             Gauge::Normal { .. } => 0.02,
@@ -222,7 +222,7 @@ impl Gauge {
         }
     }
 
-    pub fn value(&self) -> f32 {
+    pub const fn value(&self) -> f32 {
         match self {
             Gauge::None => 0.0,
             Gauge::Normal { value, .. } => *value,

--- a/game/src/game/graphics.rs
+++ b/game/src/game/graphics.rs
@@ -102,7 +102,7 @@ pub(crate) struct GlVertex {
 }
 
 impl GlVertex {
-    pub fn new(pos: [f32; 3], uv: [f32; 2]) -> Self {
+    pub const fn new(pos: [f32; 3], uv: [f32; 2]) -> Self {
         GlVertex {
             pos: GlVec3 {
                 x: pos[0],

--- a/game/src/game/graphics.rs
+++ b/game/src/game/graphics.rs
@@ -228,7 +228,7 @@ pub(crate) fn generate_slam_verts(
         //exit square
         let x0 = end - w - xoff;
         let x1 = end - xoff;
-        let y0 = y + height * 2.0;
+        let y0 = height.mul_add(2.0, y);
         let y1 = y + height;
         vertices.append(&mut vec![
             GlVertex::new([y0, 0.0, x0], [0.0, 0.0]),

--- a/game/src/game/lua_data.rs
+++ b/game/src/game/lua_data.rs
@@ -108,7 +108,13 @@ impl HitWindow {
         slam: Duration::from_nanos(83_333_333),
     };
 
-    pub fn new(variant: i32, perfect_ms: u64, good_ms: u64, hold_ms: u64, miss_ms: u64) -> Self {
+    pub const fn new(
+        variant: i32,
+        perfect_ms: u64,
+        good_ms: u64,
+        hold_ms: u64,
+        miss_ms: u64,
+    ) -> Self {
         Self {
             variant,
             perfect: Duration::from_millis(perfect_ms),

--- a/game/src/game_main.rs
+++ b/game/src/game_main.rs
@@ -64,7 +64,7 @@ pub enum AutoPlay {
 }
 
 impl AutoPlay {
-    pub fn any(&self) -> bool {
+    pub const fn any(&self) -> bool {
         !matches!(self, AutoPlay::None)
     }
 }

--- a/game/src/help.rs
+++ b/game/src/help.rs
@@ -132,11 +132,11 @@ impl AsyncPicker {
         Self(self.0.set_file_name(file_name), self.1)
     }
 
-    pub fn folder(mut self) -> Self {
+    pub const fn folder(mut self) -> Self {
         self.1 = false;
         self
     }
-    pub fn file(mut self) -> Self {
+    pub const fn file(mut self) -> Self {
         self.1 = true;
         self
     }

--- a/game/src/shaded_mesh.rs
+++ b/game/src/shaded_mesh.rs
@@ -213,7 +213,7 @@ impl ShadedMesh {
         })
     }
 
-    pub fn with_transform(mut self, transform: Mat4) -> Self {
+    pub const fn with_transform(mut self, transform: Mat4) -> Self {
         self.transform = transform;
         self
     }

--- a/game/src/song_provider/mod.rs
+++ b/game/src/song_provider/mod.rs
@@ -119,7 +119,7 @@ impl From<SongSort> for (rusc_database::SortColumn, rusc_database::SortDir) {
 }
 
 impl SongSort {
-    pub fn new(sort_type: SongSortType, direction: SortDir) -> Self {
+    pub const fn new(sort_type: SongSortType, direction: SortDir) -> Self {
         Self {
             sort_type,
             direction,
@@ -173,7 +173,7 @@ pub struct SongFilter {
 }
 
 impl SongFilter {
-    pub fn new(filter_type: SongFilterType, level: u8) -> Self {
+    pub const fn new(filter_type: SongFilterType, level: u8) -> Self {
         Self { filter_type, level }
     }
 }
@@ -292,7 +292,7 @@ impl Default for SongDiffId {
 }
 
 impl SongDiffId {
-    pub fn get_diff(&self) -> Option<&DiffId> {
+    pub const fn get_diff(&self) -> Option<&DiffId> {
         match self {
             SongDiffId::Missing => None,
             SongDiffId::DiffOnly(d) => Some(d),
@@ -300,7 +300,7 @@ impl SongDiffId {
         }
     }
 
-    pub fn get_song(&self) -> Option<&SongId> {
+    pub const fn get_song(&self) -> Option<&SongId> {
         match self {
             SongDiffId::Missing => None,
             SongDiffId::DiffOnly(_) => None,

--- a/game/src/take_duration_fade.rs
+++ b/game/src/take_duration_fade.rs
@@ -91,7 +91,7 @@ where
 
     /// Returns a reference to the inner source.
     #[inline]
-    pub fn inner(&self) -> &I {
+    pub const fn inner(&self) -> &I {
         &self.input
     }
 

--- a/kson-music-playback/src/lib.rs
+++ b/kson-music-playback/src/lib.rs
@@ -202,7 +202,7 @@ impl AudioPlayback {
         }
     }
 
-    pub fn leadin(&self) -> Duration {
+    pub const fn leadin(&self) -> Duration {
         self.leadin
     }
 

--- a/kson-music-playback/src/lib.rs
+++ b/kson-music-playback/src/lib.rs
@@ -378,7 +378,7 @@ impl AudioPlayback {
 
     pub fn get_ms(&self) -> f64 {
         if let Some(file) = &self.file {
-            file.get_ms() + (self.leadin.as_secs_f64() * 1000.0)
+            self.leadin.as_secs_f64().mul_add(1000.0, file.get_ms())
         } else {
             0.0
         }

--- a/kson-rodio-sources/src/biquad.rs
+++ b/kson-rodio-sources/src/biquad.rs
@@ -35,7 +35,7 @@ impl Default for BiQuadState {
 }
 
 impl BiQuadState {
-    pub fn new(filter: BiQuadType, q: f32, freq: f32) -> Self {
+    pub const fn new(filter: BiQuadType, q: f32, freq: f32) -> Self {
         BiQuadState {
             filter_type: filter,
             q,

--- a/kson-rodio-sources/src/gate.rs
+++ b/kson-rodio-sources/src/gate.rs
@@ -55,7 +55,7 @@ where
 
         self.cursor = (self.cursor + 1) % self.length;
         let mix = if self.cursor > self.gated_after {
-            self.amount * self.mix + (1.0 - self.mix)
+            self.amount.mul_add(self.mix, 1.0 - self.mix)
         } else {
             1.0
         };

--- a/kson-rodio-sources/src/noise.rs
+++ b/kson-rodio-sources/src/noise.rs
@@ -9,7 +9,7 @@ pub struct NoiseSource {
 }
 
 impl NoiseSource {
-    pub fn new(sample_rate: u32, amplitude: f32, channels: u16) -> Self {
+    pub const fn new(sample_rate: u32, amplitude: f32, channels: u16) -> Self {
         NoiseSource {
             sample_rate,
             amplitude,

--- a/kson-rodio-sources/src/owned_source.rs
+++ b/kson-rodio-sources/src/owned_source.rs
@@ -67,7 +67,7 @@ where
 {
     /// Returns a reference to the inner source.
     #[inline]
-    pub fn inner(&self) -> &I {
+    pub const fn inner(&self) -> &I {
         &self.input
     }
 

--- a/kson-rodio-sources/src/side_chain.rs
+++ b/kson-rodio-sources/src/side_chain.rs
@@ -71,8 +71,10 @@ where
             1.0
         };
         // range from 1/ratio (volume=0) to 1 (volume=1)
-        let sample_gain =
-            self.mix * ((1.0 / self.ratio) + (1.0 - 1.0 / self.ratio) * volume) + (1.0 - self.mix);
+        let sample_gain = self.mix.mul_add(
+            (1.0 - 1.0 / self.ratio).mul_add(volume, 1.0 / self.ratio),
+            1.0 - self.mix,
+        );
 
         self.channel = (self.channel + 1) % self.channels;
 

--- a/kson-rodio-sources/src/triangle.rs
+++ b/kson-rodio-sources/src/triangle.rs
@@ -25,7 +25,7 @@ impl Iterator for TriangleWave {
         let phase_increment = 2.0 * self.frequency / self.sample_rate as f32;
         self.phase = (self.phase + phase_increment) % 2.0;
 
-        Some(2.0 * self.amplitude * (self.phase - 1.0).abs() - self.amplitude)
+        Some((2.0 * self.amplitude).mul_add((self.phase - 1.0).abs(), -self.amplitude))
     }
 }
 

--- a/kson-rodio-sources/src/triangle.rs
+++ b/kson-rodio-sources/src/triangle.rs
@@ -8,7 +8,7 @@ pub struct TriangleWave {
 }
 
 impl TriangleWave {
-    pub fn new(frequency: f32, amplitude: f32, sample_rate: u32, phase: f32) -> Self {
+    pub const fn new(frequency: f32, amplitude: f32, sample_rate: u32, phase: f32) -> Self {
         Self {
             frequency,
             amplitude,

--- a/kson-rodio-sources/src/wobble.rs
+++ b/kson-rodio-sources/src/wobble.rs
@@ -49,7 +49,7 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.update += 1;
-        let wobble_phase = self.wobble.next().unwrap_or_default() * 0.5 + 0.5;
+        let wobble_phase = self.wobble.next().unwrap_or_default().mul_add(0.5, 0.5);
         if self.update >= self.input.channels() as u32 * 10 {
             let freq = self.f_min * (self.f_max / self.f_min).powf(wobble_phase);
 

--- a/kson/src/effects.rs
+++ b/kson/src/effects.rs
@@ -39,7 +39,7 @@ pub enum AudioEffect {
 }
 
 impl AudioEffect {
-    pub fn name(&self) -> &'static str {
+    pub const fn name(&self) -> &'static str {
         match self {
             AudioEffect::ReTrigger(_) => "ReTrigger",
             AudioEffect::Gate(_) => "Gate",

--- a/kson/src/graph.rs
+++ b/kson/src/graph.rs
@@ -33,9 +33,9 @@ impl Graph<f64> for Vec<GraphPoint> {
                     let width = end_p.v - start_v;
                     let (a, b) = (start_p.a, start_p.b);
                     if (a - b).abs() > f64::EPSILON {
-                        start_v + do_curve(x, a, b) * width
+                        do_curve(x, a, b).mul_add(width, start_v)
                     } else {
-                        start_v + x * width
+                        x.mul_add(width, start_v)
                     }
                 }
             }
@@ -101,10 +101,10 @@ impl Graph<Option<f64>> for Vec<GraphSectionPoint> {
                 let width = end_p.v - start_v;
                 let (a,b) =  (start_p.a, start_p.b);
                 if (a-b).abs() > f64::EPSILON {
-                    Some(start_v + do_curve(x, a, b) * width)
+                    Some(do_curve(x, a, b).mul_add(width, start_v))
                 }
                 else {
-                    Some(start_v + x * width)
+                    Some(x.mul_add(width, start_v))
                 }
             }
         }

--- a/kson/src/ksh.rs
+++ b/kson/src/ksh.rs
@@ -44,7 +44,7 @@ impl std::fmt::Display for KshReadError {
 }
 
 impl KshReadErrorDetails {
-    fn at_line(self, line: usize) -> KshReadError {
+    const fn at_line(self, line: usize) -> KshReadError {
         KshReadError { error: self, line }
     }
 }

--- a/kson/src/lib.rs
+++ b/kson/src/lib.rs
@@ -53,7 +53,7 @@ impl Side {
     pub fn iter() -> std::array::IntoIter<Side, 2> {
         [Self::Left, Self::Right].into_iter()
     }
-    pub fn opposite(&self) -> Self {
+    pub const fn opposite(&self) -> Self {
         match self {
             Side::Left => Self::Right,
             Side::Right => Self::Left,
@@ -240,7 +240,7 @@ impl Serialize for GraphSectionPoint {
 pub type ByMeasureIdx<T> = Vec<(u32, T)>;
 
 impl GraphSectionPoint {
-    pub fn new(ry: u32, v: f64) -> Self {
+    pub const fn new(ry: u32, v: f64) -> Self {
         GraphSectionPoint {
             ry,
             v,
@@ -359,7 +359,7 @@ pub struct LaserSection(
 );
 
 impl LaserSection {
-    pub fn tick(&self) -> u32 {
+    pub const fn tick(&self) -> u32 {
         self.0
     }
     pub fn segments(&self) -> Windows<GraphSectionPoint> {
@@ -374,7 +374,7 @@ impl LaserSection {
         self.1.first()
     }
 
-    pub fn wide(&self) -> u8 {
+    pub const fn wide(&self) -> u8 {
         self.2
     }
 }
@@ -401,7 +401,7 @@ pub struct NoteInfo {
 }
 
 impl NoteInfo {
-    fn new() -> NoteInfo {
+    const fn new() -> NoteInfo {
         NoteInfo {
             bt: [Vec::new(), Vec::new(), Vec::new(), Vec::new()],
             fx: [Vec::new(), Vec::new()],
@@ -446,7 +446,7 @@ pub struct GaugeInfo {
 }
 
 impl MetaInfo {
-    fn new() -> MetaInfo {
+    const fn new() -> MetaInfo {
         MetaInfo {
             title: String::new(),
             title_img_filename: None,
@@ -471,15 +471,15 @@ pub type ByPulse<T> = Vec<(u32, T)>;
 pub struct ByPulseOption<T>(u32, Option<T>);
 
 impl<T> ByPulseOption<T> {
-    pub fn tick(&self) -> u32 {
+    pub const fn tick(&self) -> u32 {
         self.0
     }
 
-    pub fn value(&self) -> Option<&T> {
+    pub const fn value(&self) -> Option<&T> {
         self.1.as_ref()
     }
 
-    pub fn new(y: u32, v: Option<T>) -> Self {
+    pub const fn new(y: u32, v: Option<T>) -> Self {
         Self(y, v)
     }
 }
@@ -666,7 +666,7 @@ pub struct BeatInfo {
 pub const KSON_RESOLUTION: u32 = 240;
 
 impl BeatInfo {
-    fn new() -> Self {
+    const fn new() -> Self {
         BeatInfo {
             bpm: Vec::new(),
             time_sig: Vec::new(),
@@ -802,7 +802,7 @@ pub struct BgInfo {
 }
 
 impl BgInfo {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             filename: None,
             offset: 0,

--- a/kson/src/lib.rs
+++ b/kson/src/lib.rs
@@ -382,11 +382,11 @@ impl LaserSection {
 //https://github.com/m4saka/ksh2kson/issues/4#issuecomment-573343229
 pub fn do_curve(x: f64, a: f64, b: f64) -> f64 {
     let t = if x < f64::EPSILON || a < f64::EPSILON {
-        (a - (a * a + x - 2.0 * a * x).sqrt()) / (-1.0 + 2.0 * a)
+        (a - (2.0 * a).mul_add(-x, a.mul_add(a, x)).sqrt()) / 2.0f64.mul_add(a, -1.0)
     } else {
-        x / (a + (a * a + (1.0 - 2.0 * a) * x).sqrt())
+        x / (a + a.mul_add(a, 2.0f64.mul_add(-a, 1.0) * x).sqrt())
     };
-    2.0 * (1.0 - t) * t * b + t * t
+    (2.0 * (1.0 - t) * t).mul_add(b, t * t)
 }
 
 fn default_one<T: From<u8>>() -> T {

--- a/kson/src/parameter.rs
+++ b/kson/src/parameter.rs
@@ -132,11 +132,11 @@ impl EffectParam for RangeInclusive<f32> {
             InterpolationShape::Logarithmic => {
                 let sln = self.start().ln();
                 let wn = self.end().ln() - sln;
-                (sln + wn * v).exp()
+                wn.mul_add(v, sln).exp()
             }
             InterpolationShape::Smooth => {
                 //https://en.wikipedia.org/wiki/Smoothstep
-                self.start() + (v * v * v * (v * (v * 6.0 - 15.0) + 10.0)) * w
+                self.start() + (v * v * v * v.mul_add(v.mul_add(6.0, -15.0), 10.0)) * w
             }
         }
     }

--- a/kson/src/parameter.rs
+++ b/kson/src/parameter.rs
@@ -86,7 +86,7 @@ trait EffectParam {
 }
 
 impl EffectParameterValue {
-    pub fn default_shape(&self) -> InterpolationShape {
+    pub const fn default_shape(&self) -> InterpolationShape {
         match self {
             EffectParameterValue::Freq(_) => InterpolationShape::Logarithmic,
             _ => InterpolationShape::Linear,

--- a/kson/src/score_ticks.rs
+++ b/kson/src/score_ticks.rs
@@ -9,7 +9,7 @@ pub enum ScoreTick {
 }
 
 impl ScoreTick {
-    pub fn lane(&self) -> usize {
+    pub const fn lane(&self) -> usize {
         match self {
             ScoreTick::Laser { lane, pos: _ } => *lane,
             ScoreTick::Slam {
@@ -22,7 +22,7 @@ impl ScoreTick {
         }
     }
 
-    pub fn global_lane(&self) -> usize {
+    pub const fn global_lane(&self) -> usize {
         match self {
             ScoreTick::Laser { .. } | ScoreTick::Slam { .. } => self.lane() + 6,
             _ => self.lane(),


### PR DESCRIPTION
There is a fair amount of low hanging fruit for cleaning up the code, increasing math accuracy, and performance.

This PR in particular looks at the float operations and function signatures across the entire repo.

**missing_const_for_fn**
- Many functions without modification can be made const (compile time)

**suboptimal_flops** (Generally, we can apply SIMD intrinsics for better performance/accuracy)
- [`mul_add`](https://doc.rust-lang.org/std/primitive.f32.html#method.mul_add) can be used wherever possible for significantly greater floating point operation accuracy and performance. It should only require about half the CPU cycles and only needs to round once instead of twice. See https://en.wikipedia.org/wiki/FMA_instruction_set
- In one spot `powf(0.5)` was used, but `sqrt()` should always be more performant with no downsides.
- `powi` is also faster and more accurate than `powf`, so it should be used instead of `powf(int.0)` (`powf(3.0)` should become `powi(3)` for example).

I tried to be as careful as absolutely possible with these, but even still, making some operations more accurate may change their behavior in difficult ways. In particular, `camera:215` probably needs to be looked at.

If this PR is acceptable, I would be glad to continue working through other lint patterns where most appropriate.